### PR TITLE
Update of README.md to include static analysis tool and team's wiki access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### Wikipedia Android Application [![Codacy Badge](https://api.codacy.com/project/badge/Grade/ae8afa49051743029cc5d5ba32fa2b87)](https://app.codacy.com/app/jadmalek/android-wikipedia-390?utm_source=github.com&utm_medium=referral&utm_content=amawai/android-wikipedia-390&utm_campaign=badger)
 
-This repository contains the source code for the official Wikipedia Android application as well as additional features implemented by Software Engineering students from Concordia University
+This repository contains the source code for the official Wikipedia Android application as well as additional features implemented by Software Engineering students from Concordia University.
 
 ### Documentation
 
-All documentation is kept on the [official Wikimedia wiki](https://www.mediawiki.org/wiki/Wikimedia_Apps/Team/Wikipedia_Android_app_hacking). The documentation pertaining to the android-wikiped-390 team's contributions is kept in [our wiki](https://github.com/amawai/android-wikipedia-390/wiki). Check it out!
+All documentation is kept on the [official Wikimedia wiki](https://www.mediawiki.org/wiki/Wikimedia_Apps/Team/Wikipedia_Android_app_hacking). The documentation pertaining to the android-wikipedia-390 team's contributions is kept in [our wiki](https://github.com/amawai/android-wikipedia-390/wiki). Check it out!

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-### Wikipedia Android app
+### Wikipedia Android Application [![Codacy Badge](https://api.codacy.com/project/badge/Grade/ae8afa49051743029cc5d5ba32fa2b87)](https://app.codacy.com/app/jadmalek/android-wikipedia-390?utm_source=github.com&utm_medium=referral&utm_content=amawai/android-wikipedia-390&utm_campaign=badger)
 
-This repository contains the source code for the official Wikipedia Android app.
+This repository contains the source code for the official Wikipedia Android application as well as additional features implemented by Software Engineering students from Concordia University
 
 ### Documentation
 
-All documentation is kept on [our wiki](https://www.mediawiki.org/wiki/Wikimedia_Apps/Team/Wikipedia_Android_app_hacking). Check it out!
+All documentation is kept on the [official Wikimedia wiki](https://www.mediawiki.org/wiki/Wikimedia_Apps/Team/Wikipedia_Android_app_hacking). The documentation pertaining to the android-wikiped-390 team's contributions is kept in [our wiki](https://github.com/amawai/android-wikipedia-390/wiki). Check it out!


### PR DESCRIPTION
Technically both commits address #79 but there is no code contained with this PR that is relevant to the actual analysis integration. This is merely meant for general information purposes now that repository is public. 